### PR TITLE
Pretty up yard based on dragonfly

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,11 +1,8 @@
---title "Afterburner CMS"
+--main README.md
+-e ./yard/setup.rb
 --markup-provider=kramdown
 --markup=markdown
-core/**/*
-delivery/**/*
-lib/**/*
+--asset documentation/architecture.png:architecture.png
 -
 README.md
-contributing.md
 documentation/architecture.md
-

--- a/yard/setup.rb
+++ b/yard/setup.rb
@@ -1,0 +1,10 @@
+require File.expand_path('../lib/abc/package', File.dirname(__FILE__))
+
+this_dir = File.dirname(__FILE__)
+
+YARD::Templates::Engine.register_template_path(this_dir + '/templates')
+
+Dir[this_dir + '/handlers/*.rb'].each do |file|
+  require File.expand_path(file)
+end
+YARD::Parser::SourceParser.parser_type = :ruby19

--- a/yard/templates/default/fulldoc/html/css/common.css
+++ b/yard/templates/default/fulldoc/html/css/common.css
@@ -1,0 +1,109 @@
+/* Overrides for yard documentation */
+
+/* Clearfix */
+.clearfix:after {
+	content: ".";
+	display: block;
+	clear: both;
+	visibility: hidden;
+	line-height: 0;
+	height: 0;
+}
+
+.clearfix {
+	display: inline-block;
+}
+
+html[xmlns] .clearfix {
+	display: block;
+}
+
+* html .clearfix {
+	height: 1%;
+}
+ /************/
+
+body {
+  font-family: "PT Sans",Verdana,Arial,sans-serif;
+  font-size: 14px;
+}
+
+pre, code, .code,
+#filecontents pre.code,
+.docstring pre.code,
+.source_code pre {
+  font-family: Inconsolata,Monaco,"Courier New","DejaVu Sans Mono","Bitstream Vera Sans Mono",monospace;
+}
+
+pre.code, code {
+  background:#F5F5FF;
+  overflow-x: auto;
+}
+#filecontents pre.code {
+  margin:10px 0;
+  padding:5px 12px;
+  border-radius:5px;
+  -webkit-border-radius:5px;
+  -moz-border-radius:5px;
+  border: 1px dotted #CCC;
+}
+
+code .val {
+  color:#036A07;
+}
+code .kw {
+  color:#0000FF;
+}
+code .symbol {
+  color:#C5060B;
+}
+
+ul.main_files {
+  list-style-type:none;
+  margin:0;
+  padding:0;
+  font-size:14px;
+}
+ul.main_files li {
+  margin:0;
+  padding:0;
+}
+
+ul.main_files li a {
+  margin: 0;
+  padding:3px 12px;
+  display:block;
+  cursor:pointer;
+}
+#content ul.main_files li a:hover {
+  background-color:#F4F9E4;
+}
+/* Layout */
+#header,
+#content,
+#footer {
+  margin:0 auto;
+  width:1000px;
+}
+#header #logo {
+  float:left;
+  width:50%;
+  font-size: 32px;
+  letter-spacing: -1px;
+  margin-top: 20px;
+}
+#header #search {
+  position:static;
+  float:right;
+}
+#content .col1 {
+  float:left;
+  width: 750px;
+}
+#content .col2 {
+  float:left;
+  margin: 0 0 0 20px;
+  padding: 0 0 0 20px;
+  width: 200px;
+  border-left: 1px dotted #D5D5D5;
+}

--- a/yard/templates/default/layout/html/layout.erb
+++ b/yard/templates/default/layout/html/layout.erb
@@ -1,0 +1,56 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+  <head>
+    <%= erb(:headers) %>
+    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Inconsolata">
+    <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=PT+Sans">
+    <script type="text/javascript" charset="utf-8">
+      (function($){
+        // YARD automatically creates a table of contents
+        // Let's place it inside .col1, instead of #content
+        $(document).ready(function(){
+          $('#toc').prependTo($('.col1'));
+          <% if options[:file] == 'extra_docs/Index.md' %>
+            $('#toc').hide();
+          <% end %>
+        });
+      })(jQuery);
+    </script>
+  </head>
+  <body>
+
+    <script type="text/javascript" charset="utf-8">
+      if (window.top.frames.main) document.body.className = 'frames';
+    </script>
+
+    <div id="header" class="clearfix">
+      <%#= erb(:breadcrumb) %>
+      <div id="logo">Afterburner CMS (v <%= Abc::VERSION %>)</div>
+      <%= erb(:search) %>
+    </div>
+
+    <div>
+      <iframe id="search_frame"></iframe>
+    </div>
+
+    <div id="content" class="clearfix">
+      <div class="col1">
+        <%= yieldall %>
+      </div>
+      <div class="col2">
+        <ul class="main_files clearfix">
+          <%= [
+            ['README', 'README'],
+            ['architecture', 'Architecture Details']
+          ].map{|(file, text)|
+            "<li>#{link_file(file, text)}</li>"
+          }.join
+          %>
+        </ul>
+      </div>
+    </div>
+
+    <%= erb(:footer) %>
+  </body>
+</html>


### PR DESCRIPTION
So for some reason the custom css isn't visible when running `yard server`.  A `yard doc` will generate them and then you can see the custom css.  My guess is that this is an actual bug in yard - verified that the appropriate paths are registered, etc.

Also we'll need to address the images-in-docs (yard doesn't copy over referenced images by default, I need to figure that out).  I plan to send a tweak momentarily that will just point to the image on github for now - will work at least.
