### PR TITLE
Wire up an entity from the ShowsPage Conductor

### DIFF
--- a/delivery/frontend/Gemfile
+++ b/delivery/frontend/Gemfile
@@ -29,4 +29,4 @@ group :development do
 end
 
 gem 'abc-core', :path => '../../core'
-gem 'abc-adapters', :path => '../../adapters'
+#gem 'abc-adapters', :path => '../../adapters'

--- a/delivery/frontend/abc-frontend.gemspec
+++ b/delivery/frontend/abc-frontend.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml-rails'
 
   s.add_dependency 'abc-core', Abc::VERSION
-  s.add_dependency 'abc-adapters', Abc::VERSION
+  #s.add_dependency 'abc-adapters', Abc::VERSION
 end

--- a/delivery/frontend/app/conductors/abc/frontend/conductors/shows_page.rb
+++ b/delivery/frontend/app/conductors/abc/frontend/conductors/shows_page.rb
@@ -1,5 +1,5 @@
 require 'abc/html/page_presenter'
-require 'ostruct'
+require 'abc/entities/content/text'
 
 module Abc
   module Frontend
@@ -35,7 +35,9 @@ module Abc
         # Here, we can transform our params into the data we want to return
         # We could hit up any adapter or API we want.
         def data
-          OpenStruct.new(params)
+          # TODO: For now we've mocked out a path in which we received a
+          # Text entity from some Interactor.
+          Abc::Entities::Content::Text.new("Welcome to page #{params[:id]}")
         end
 
       end

--- a/delivery/frontend/app/presenters/abc/html/page_presenter.rb
+++ b/delivery/frontend/app/presenters/abc/html/page_presenter.rb
@@ -5,8 +5,8 @@ module Abc
         @page = page
       end
 
-      def id
-        @page.id
+      def content
+        @page.to_s
       end
     end
   end

--- a/delivery/frontend/app/views/abc/frontend/pages/show.html.haml
+++ b/delivery/frontend/app/views/abc/frontend/pages/show.html.haml
@@ -1,2 +1,1 @@
-Welcome to page
-= @data.page.id
+= @data.page.content

--- a/delivery/frontend/spec/conductors/abc/frontend/shows_page_spec.rb
+++ b/delivery/frontend/spec/conductors/abc/frontend/shows_page_spec.rb
@@ -3,7 +3,7 @@ require 'abc/frontend/conductors/shows_page'
 
 class MockPagePresenter
   def initialize(vals); @vals = vals; end
-  def id; @vals.id; end
+  def content; @vals.to_s; end
 end
 
 module Abc
@@ -12,7 +12,7 @@ module Abc
       describe ShowsPage do
         it "returns a page presenter" do
           result = ShowsPage.call({:id => 1}, {:presenter_class => MockPagePresenter})
-          result[:page].id.should == 1
+          result[:page].content.should == "Welcome to page 1"
         end
       end
     end

--- a/delivery/frontend/spec/presenters/html/page_presenter_spec.rb
+++ b/delivery/frontend/spec/presenters/html/page_presenter_spec.rb
@@ -5,8 +5,14 @@ require 'ostruct'
 module Abc
   module Html
     describe PagePresenter do
-      subject { PagePresenter.new(OpenStruct.new(:id => 1)) }
-      its(:id) { should == 1 }
+      let(:page) do
+        p = mock('page')
+        p.stub(:to_s).and_return('foo')
+        p
+      end
+      subject { PagePresenter.new(page) }
+
+      its(:content) { should == 'foo' }
     end
   end
 end


### PR DESCRIPTION
This is a very temporary step, but the goal is to make it clear how an
entity will be passed to the presenter in this portion of the
application flow.

No idea if this is what you were looking for @robyurkowski but here it is anyway :)
